### PR TITLE
Issue 9: Completed refactoring so that the work for #3 can be carried out

### DIFF
--- a/src/main/java/org/jboss/mjolnir/client/AbstractGithubNameScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/AbstractGithubNameScreen.java
@@ -1,0 +1,114 @@
+package org.jboss.mjolnir.client;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.DialogBox;
+import com.google.gwt.user.client.ui.Grid;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import org.jboss.mjolnir.authentication.KerberosUser;
+
+/**
+ * Class that will essentially have the place-holders for the common UI's in the Add and Modify name screens.
+ *
+ * @version : 0.3
+ * @author: navssurtani
+ */
+public abstract class AbstractGithubNameScreen extends Composite {
+    protected String krb5Name;
+    protected RootPanel githubNamePanel;
+    protected LoginServiceAsync loginService;
+    protected TextBox nameField;
+    protected Grid formGrid;
+
+    protected AbstractGithubNameScreen(String krb5Name, String panelName) {
+        this.krb5Name = krb5Name;
+        this.githubNamePanel = RootPanel.get(panelName);
+        this.loginService = LoginService.Util.getInstance();
+    }
+
+    protected Button buildSubmitButton() {
+        Button b = new Button("Submit");
+        b.setEnabled(true);
+        b.getElement().setId("Submit");
+        return b;
+    }
+
+    protected void displayPopupBox(String header, String message) {
+        final DialogBox box = new DialogBox();
+        box.setText(header);
+        final HTML html = new HTML();
+        html.setHTML(message);
+        VerticalPanel verticalPanel = new VerticalPanel();
+        verticalPanel.setHorizontalAlignment(VerticalPanel.ALIGN_CENTER);
+        final Button closeButton = buildCloseButton(box);
+        verticalPanel.add(html);
+        verticalPanel.add(closeButton);
+        box.setWidget(verticalPanel);
+        box.center();
+    }
+
+    private Button buildCloseButton(final DialogBox box) {
+        final Button closeButton = new Button("Close");
+        closeButton.setEnabled(true);
+        closeButton.getElement().setId("Close");
+        closeButton.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                box.hide();
+            }
+        });
+        return closeButton;
+    }
+
+    private void executeRegistration() {
+        loginService.registerKerberosUser(krb5Name, nameField.getText(), new AsyncCallback<KerberosUser>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                displayPopupBox("Error with registration", caught.getMessage());
+            }
+
+            @Override
+            public void onSuccess(KerberosUser user) {
+                githubNamePanel.remove(formGrid);
+                EntryPage.getInstance().moveToSubscriptionScreen(user.getName());
+            }
+        });
+    }
+
+    private void executeUpdate() {
+        // This method is not supported as yet.
+        displayPopupBox("Unsupported!", "You should not see this error box!");
+    }
+
+    protected class NameHandler implements ClickHandler, KeyUpHandler {
+
+        private final boolean isRegistered;
+
+        protected NameHandler(boolean isRegistered) {
+            this.isRegistered = isRegistered;
+        }
+
+        @Override
+        public void onClick(ClickEvent event) {
+            if (!isRegistered) executeRegistration();
+            else executeUpdate();
+        }
+
+        @Override
+        public void onKeyUp(KeyUpEvent event) {
+            if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+                if (!isRegistered) executeRegistration();
+                else executeUpdate();
+            }
+        }
+    }
+}

--- a/src/main/java/org/jboss/mjolnir/client/EntryPage.java
+++ b/src/main/java/org/jboss/mjolnir/client/EntryPage.java
@@ -24,19 +24,18 @@ package org.jboss.mjolnir.client;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.user.client.ui.RootPanel;
-import org.jboss.mjolnir.authentication.KerberosUser;
 
 /**
  * @author: navssurtani
  * @since: 0.1
  */
 
-public class LoginPage implements EntryPoint {
+public class EntryPage implements EntryPoint {
 
-    /** Singleton LoginPage **/
-    private static LoginPage instance;
+    /** Singleton EntryPage **/
+    private static EntryPage instance = new EntryPage();
 
-    public static LoginPage getInstance() {
+    public static EntryPage getInstance() {
         return instance;
     }
 
@@ -50,9 +49,13 @@ public class LoginPage implements EntryPoint {
         RootPanel.get().add(loginScreen);
     }
 
-    public void setSuccessScreen(KerberosUser user) {
-        SubscriptionScreen subscriptionScreen = new SubscriptionScreen(user);
+    public void moveToSubscriptionScreen(final String krb5Name) {
+        SubscriptionScreen subscriptionScreen = new SubscriptionScreen(krb5Name);
         RootPanel.get().add(subscriptionScreen);
     }
 
+    public void moveToGithubRegistrationScreen(String krb5Name) {
+        AbstractGithubNameScreen registerScreen = new RegisterGithubNameScreen(krb5Name);
+        RootPanel.get().add(registerScreen);
+    }
 }

--- a/src/main/java/org/jboss/mjolnir/client/LoginService.java
+++ b/src/main/java/org/jboss/mjolnir/client/LoginService.java
@@ -44,7 +44,8 @@ import java.util.Set;
 @XsrfProtect
 public interface LoginService extends RemoteService {
 
-    boolean login (String krb5Name, String password) throws LoginFailedException;
+    boolean login(String krb5Name, String password) throws LoginFailedException;
+    boolean isRegistered(String krb5Name);
     KerberosUser getKerberosUser(String krb5Name);
     KerberosUser registerKerberosUser(String krb5Name, String githubName) throws RuntimeException;
     void logout();

--- a/src/main/java/org/jboss/mjolnir/client/LoginServiceAsync.java
+++ b/src/main/java/org/jboss/mjolnir/client/LoginServiceAsync.java
@@ -23,4 +23,6 @@ public interface  LoginServiceAsync {
     void unsubscribe(String orgName, int teamId, String githubName, AsyncCallback<Void> async);
 
     void subscribe(String orgName, int teamId, String githubName, AsyncCallback<Void> async);
+
+    void isRegistered(String krb5Name, AsyncCallback<Boolean> async);
 }

--- a/src/main/java/org/jboss/mjolnir/client/RegisterGithubNameScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/RegisterGithubNameScreen.java
@@ -1,0 +1,44 @@
+package org.jboss.mjolnir.client;
+
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Grid;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.TextBox;
+
+/**
+ * Screen that will allow for a user to be able to add their github username upon logging in for the first time.
+ *
+ * @author: navssurtani
+ * @version : 0.3
+ */
+public class RegisterGithubNameScreen extends AbstractGithubNameScreen {
+
+    // We would need the kerberos-id of the user in order to add it on to the server side.
+    public RegisterGithubNameScreen(String krb5Name) {
+        super(krb5Name, "registerPanelContainer");
+        buildAndDisplayForm();
+    }
+
+    private void buildAndDisplayForm() {
+        // Here we do the work of displaying the form which will make an RPC call to edit a user's details.
+        // Instantiate the handler. In this case, the isRegistered parameter would be false.
+        NameHandler handler = new NameHandler(false);
+
+        nameField = new TextBox();
+        nameField.setTitle("Github username");
+        nameField.addKeyUpHandler(handler);
+
+        Button submitButton = buildSubmitButton();
+        submitButton.addClickHandler(handler);
+
+        formGrid = new Grid(3, 2);
+        formGrid.setWidget(0, 0, new Label("Enter your github username"));
+        formGrid.setWidget(0, 1, new Label("E.g.: 'myusername'."));
+        formGrid.setWidget(1, 1, new Label("[This should NOT be the email address you use]"));
+        formGrid.setWidget(2, 0, nameField);
+        formGrid.setWidget(2, 1, submitButton);
+
+        githubNamePanel.add(formGrid);
+    }
+}

--- a/src/main/java/org/jboss/mjolnir/client/SubscriptionScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/SubscriptionScreen.java
@@ -52,12 +52,19 @@ public class SubscriptionScreen extends Composite {
     private LoginServiceAsync loginService;
     private RootPanel successPanel = RootPanel.get("subscriptionPanelContainer");
 
-    public SubscriptionScreen(KerberosUser user) {
-        this.user = user;
+    public SubscriptionScreen(String krb5Name) {
         loginService = LoginService.Util.getInstance();
+        loginService.getKerberosUser(krb5Name, new AsyncCallback<KerberosUser>() {
+            @Override
+            public void onFailure(Throwable caught) {
+                displayPopupBox("Could not retrieve user details", caught.getMessage());
+            }
 
-        String introductionString = "Organizations and teams subscribed to for " + user.getGithubName();
-        successPanel.add(new Label(introductionString));
+            @Override
+            public void onSuccess(KerberosUser result) {
+                SubscriptionScreen.this.user = result;
+            }
+        });
         loadOrgsFromSubscriptionService();
     }
 
@@ -70,7 +77,6 @@ public class SubscriptionScreen extends Composite {
 
             @Override
             public void onSuccess(Set<GithubOrganization> result) {
-                successPanel.add(new Label("Result size from server is " + result.size()));
                 generateGrids(result);
             }
         });
@@ -115,18 +121,19 @@ public class SubscriptionScreen extends Composite {
     }
 
     private Button generateSubscribeButton(final String orgName, final int teamId) {
-        Button subscribeButton = crreateOperationButton("Subscribe");
+        Button subscribeButton = createOperationButton("Subscribe");
         subscribeButton.addClickHandler(new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                loginService.subscribe(orgName, teamId, user.getGithubName(), getCallBack("subscirbe", orgName, teamId));
+                loginService.subscribe(orgName, teamId, user.getGithubName(),
+                      getCallBack("subscribe", orgName, teamId));
             }
         });
         return subscribeButton;
     }
 
     private Button generateUnsubscribeButton(final String orgName, final int teamId) {
-        Button unsubscribeButton = crreateOperationButton("Unsubscribe");
+        Button unsubscribeButton = createOperationButton("Unsubscribe");
         unsubscribeButton.addClickHandler(new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
@@ -154,7 +161,7 @@ public class SubscriptionScreen extends Composite {
         return toReturn;
     }
 
-    private Button crreateOperationButton(String buttonName) {
+    private Button createOperationButton(String buttonName) {
         Button b = new Button(buttonName);
         b.setEnabled(true);
         b.getElement().setId(buttonName);

--- a/src/main/resources/github-team-data.xml
+++ b/src/main/resources/github-team-data.xml
@@ -2,28 +2,9 @@
 <github-team-data>
     <organizations>
         <organization>
-            <org-name>jbossas</org-name>
-            <token>??</token>
-            <teams>
-                <team>
-                    <team-name>EAP View</team-name>
-                    <id>338123</id>
-                </team>
-                <team>
-                    <team-name>Owners</team-name>
-                    <id>5536</id>
-                </team>
-            </teams>
-        </organization>
-
-        <organization>
             <org-name>uselessorg</org-name>
             <token>??</token>
             <teams>
-                <team>
-                    <team-name>Owners</team-name>
-                    <id>403752</id>
-                </team>
                 <team>
                     <team-name>Trial</team-name>
                     <id>405212</id>

--- a/src/main/resources/org/jboss/mjolnir/Mjolnir.gwt.xml
+++ b/src/main/resources/org/jboss/mjolnir/Mjolnir.gwt.xml
@@ -14,7 +14,7 @@
     <inherits name="com.google.gwt.rpc.RPC"/>
 
     <!-- Specify the app entry point class.-->
-    <entry-point class='org.jboss.mjolnir.client.LoginPage'/>
+    <entry-point class='org.jboss.mjolnir.client.EntryPage'/>
 
      <!--Specify the paths for translatable code -->
     <source path='client'/>

--- a/src/main/webapp/LoginPage.jsp
+++ b/src/main/webapp/LoginPage.jsp
@@ -32,6 +32,9 @@
         <tr>
             <td id="subscriptionPanelContainer"></td>
         </tr>
+        <tr>
+            <td id="registerPanelContainer"></td>
+        </tr>
     </table>
 
 </body>


### PR DESCRIPTION
- `AbstractGithubNameScreen` class was created. This will allow an extension in #3 for a user to be able to modify their github account name if necessary.
- LoginPage changed to EntryPage since it is the point of entry - just to give it a more meaningful name.
- Return type of `registerKerberosUser` on `LoginService` changed to a void return type.
- Dealt with bugs related to GWT conventions (the onSuccess() and onFailure() calls). Exceptions should only be thrown if and only if an operation was incomplete.
- Main page flow changed. The form to register a new github username within the server context was moved to it's own page.
