### PR TITLE
#13 - Added 'return to selection' buttons

### DIFF
--- a/src/main/java/org/jboss/mjolnir/client/LoginScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/LoginScreen.java
@@ -99,7 +99,7 @@ public class LoginScreen extends Composite {
             public void onSuccess(Boolean isRegistered) {
                 if (isRegistered) {
                     // Move to subscription screen.
-                    EntryPage.getInstance().moveToGithubModifyScreen(krb5Name);
+                    EntryPage.getInstance().moveToSelectionScreen(krb5Name);
 
                 } else {
                     // Move to add github name screen.

--- a/src/main/java/org/jboss/mjolnir/client/ModifyGithubNameScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/ModifyGithubNameScreen.java
@@ -1,6 +1,8 @@
 package org.jboss.mjolnir.client;
 
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Grid;
@@ -34,14 +36,31 @@ public class ModifyGithubNameScreen extends AbstractGithubNameScreen {
         Button submitButton = buildSubmitButton();
         submitButton.addClickHandler(handler);
 
-        formGrid = new Grid(5, 4);
+        Button returnButton = buildReturnToSelection();
+
+        formGrid = new Grid(6, 5);
         formGrid.setWidget(0, 0, new Label("Hello there: "));
         formGrid.setWidget(0, 2, new Label(krb5Name));
         formGrid.setWidget(2, 0, new Label("Enter your correct github username."));
         formGrid.setWidget(2, 2, new Label("Note: It should NOT be an email address"));
         formGrid.setWidget(4, 0, nameField);
         formGrid.setWidget(4, 2, submitButton);
+        formGrid.setWidget(5, 4, returnButton);
 
         githubNamePanel.add(formGrid);
+    }
+
+    private Button buildReturnToSelection() {
+        final Button returnButton = new Button("Return to Selection");
+        returnButton.setEnabled(true);
+        returnButton.getElement().setId("Return");
+        returnButton.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                githubNamePanel.remove(formGrid);
+                EntryPage.getInstance().moveToSelectionScreen(krb5Name);
+            }
+        });
+        return returnButton;
     }
 }

--- a/src/main/java/org/jboss/mjolnir/client/SubscriptionScreen.java
+++ b/src/main/java/org/jboss/mjolnir/client/SubscriptionScreen.java
@@ -50,7 +50,7 @@ public class SubscriptionScreen extends Composite {
     private KerberosUser user;
 
     private LoginServiceAsync loginService;
-    private RootPanel successPanel = RootPanel.get("subscriptionPanelContainer");
+    private RootPanel subscriptionPanel = RootPanel.get("subscriptionPanelContainer");
 
     public SubscriptionScreen(String krb5Name) {
         loginService = LoginService.Util.getInstance();
@@ -91,7 +91,7 @@ public class SubscriptionScreen extends Composite {
             // For each organization, we want the number of teams + 2.
             List<GithubTeam> teams = o.getTeams();
             int teamSize = teams.size();
-            int gridRows = teamSize + 2;
+            int gridRows = teamSize + 3;
 
             Grid orgGrid = new Grid(gridRows, gridCols);
             populateBasicContent(orgGrid, o.getName());
@@ -106,7 +106,9 @@ public class SubscriptionScreen extends Composite {
 
                 // TODO: Find a way to generate the live status of the user here.
             }
-            successPanel.add(orgGrid);
+            Button returnToSelection = buildReturnToSelection(orgGrid);
+            orgGrid.setWidget(gridRows - 1, gridCols - 1, returnToSelection);
+            subscriptionPanel.add(orgGrid);
         }
     }
 
@@ -195,4 +197,17 @@ public class SubscriptionScreen extends Composite {
         return closeButton;
     }
 
+    private Button buildReturnToSelection(final Grid orgGrid) {
+        final Button returnButton = new Button("Return to Selection");
+        returnButton.setEnabled(true);
+        returnButton.getElement().setId("Return");
+        returnButton.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                subscriptionPanel.remove(orgGrid);
+                EntryPage.getInstance().moveToSelectionScreen(user.getName());
+            }
+        });
+        return returnButton;
+    }
 }


### PR DESCRIPTION
PR to complete #13.
- Users can now go 'back to selection screen' from the ModifyGithubNameScreen and the SubscriptionScreen
- Found a bug in LoginScreen where users that were already registered move to the modification screen instead of the selection screen by mistake upon login
