### PR TITLE
rpm: set proper files attributes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,12 +286,21 @@
                     <group>JBoss SET/Tools</group>
                     <packager>JBoss SET</packager>
                     <mappings>
+                        <!-- not very elegant, but only way I found to ensure the proper files
+                             attributes were set was to "override" the first mapping with a second
+                             one ... -->
                         <mapping>
                             <directory>/usr/share/${project.name}</directory>
                             <filemode>644</filemode>
-                            <username>jboss</username>
-                            <groupname>jboss</groupname>
-                            <artifact />
+                            <username>root</username>
+                            <groupname>root</groupname>
+                            <artifact/>
+                        </mapping>
+                        <mapping>
+                            <directory>/usr/share/${project.name}</directory>
+                            <filemode>755</filemode>
+                            <username>root</username>
+                            <groupname>root</groupname>
                         </mapping>
                     </mappings>
                 </configuration>


### PR DESCRIPTION
- ensure both dir and file are owned by root
- ensure that dir mode is 755 and file mode is 640

_Side note: it's not exactly an elegant solution, because during the rpm install the files attributes are going to be modified twice, rather being directly set correctly. However, it works, and it is the only solution I managed to come up with the reduced semantics of the maven-rpm-plugin..._