### PR TITLE
Align repoID of repository.jboss.org with wildfly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,11 +414,11 @@
 
     <repositories>
         <repository>
-            <id>JBoss repository</id>
+            <id>jboss-public-repository-group</id>
             <url>http://repository.jboss.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
-            <id>jboss-public-repository-group</id>
+            <id>jboss-public-repository-group-jboss</id>
             <name>JBoss Public Maven Repository Group</name>
             <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
             <layout>default</layout>


### PR DESCRIPTION
@TomasHofman Using the same ID as Widlfly build will allow the Mjolnir build to benefits from the HTTP Caching on Thunder.

It's not ground breaking, but it's nice :) 